### PR TITLE
MIDDrv onStop callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 
-project ("hyper-sonic-drivers" VERSION 0.19.4 DESCRIPTION "Hyper-Sonic Drivers for emulating old soundcards")
+project ("hyper-sonic-drivers" VERSION 0.19.5 DESCRIPTION "Hyper-Sonic Drivers for emulating old soundcards")
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)

--- a/hyper-sonic-drivers/examples/mid-example.h
+++ b/hyper-sonic-drivers/examples/mid-example.h
@@ -63,6 +63,16 @@ void mid_test_run(drivers::MIDDriver& midDrv, const std::shared_ptr<audio::MIDI>
             spdlog::info("resuming");
             midDrv.resume();
         }
+        else if (i == 20)
+        {
+            spdlog::info("stop (3s)");
+            midDrv.stop();
+            utils::delayMillis(3000);
+            spdlog::info("play again");
+            midDrv.play();
+        }
+        else if (i == 25)
+            midDrv.stop();
     }
 
     auto end_time = std::chrono::system_clock::now();
@@ -72,7 +82,6 @@ void mid_test_run(drivers::MIDDriver& midDrv, const std::shared_ptr<audio::MIDI>
 
 void scummvm_mid_test(const OplEmulator emu, const OplType type, const std::shared_ptr<audio::IMixer>& mixer, const std::shared_ptr<audio::MIDI> midi)
 {
-
     std::shared_ptr<devices::IDevice> device;
     switch (type)
     {

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/IMidiDriver.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/IMidiDriver.hpp
@@ -66,6 +66,7 @@ protected:
     // virtual void onCallback() noexcept = 0; // TODO: consider to re-do it
 
     // virtual void onOpen() = 0;
+    virtual void onStop() noexcept   = 0;
     virtual void onPause() noexcept  = 0;
     virtual void onResume() noexcept = 0;
 
@@ -143,9 +144,11 @@ inline bool IMidiDriver::isPaused() const noexcept
 
 inline void IMidiDriver::stop() noexcept
 {
+    if (isPlaying())
+        onStop();
+
     m_paused    = false;
     m_isPlaying = false;
-    // TODO do virtual onStop to stop all the sounds
 }
 
 inline bool IMidiDriver::isTempoChanged() const noexcept

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/IMidiDriver.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/IMidiDriver.hpp
@@ -66,9 +66,9 @@ protected:
     // virtual void onCallback() noexcept = 0; // TODO: consider to re-do it
 
     // virtual void onOpen() = 0;
-    virtual void onStop() noexcept   = 0;
-    virtual void onPause() noexcept  = 0;
-    virtual void onResume() noexcept = 0;
+    virtual void onStop_() noexcept   = 0;
+    virtual void onPause_() noexcept  = 0;
+    virtual void onResume_() noexcept = 0;
 
     void callback_();
 
@@ -119,7 +119,7 @@ inline void IMidiDriver::pause() noexcept
     if (m_isPlaying && !m_paused)
     {
         m_paused = true;
-        onPause();
+        onPause_();
     }
 };
 
@@ -128,7 +128,7 @@ inline void IMidiDriver::resume() noexcept
     if (m_isPlaying && m_paused)
     {
         m_paused = false;
-        onResume();
+        onResume_();
     }
 };
 
@@ -145,7 +145,7 @@ inline bool IMidiDriver::isPaused() const noexcept
 inline void IMidiDriver::stop() noexcept
 {
     if (isPlaying())
-        onStop();
+        onStop_();
 
     m_paused    = false;
     m_isPlaying = false;

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/mt32/MT32Driver.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/mt32/MT32Driver.hpp
@@ -23,6 +23,7 @@ public:
 
 protected:
     // void onCallback() noexcept override;
+    void onStop() noexcept override {};
     void onPause() noexcept override {};
     void onResume() noexcept override {};
 

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/mt32/MT32Driver.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/mt32/MT32Driver.hpp
@@ -23,9 +23,9 @@ public:
 
 protected:
     // void onCallback() noexcept override;
-    void onStop() noexcept override {};
-    void onPause() noexcept override {};
-    void onResume() noexcept override {};
+    void onStop_() noexcept override {};
+    void onPause_() noexcept override {};
+    void onResume_() noexcept override {};
 
     // MIDI events (not implemented, directly send MIDI msg to MT32Emu service)
     void noteOff(const uint8_t chan, const uint8_t note) noexcept override;

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
@@ -83,7 +83,7 @@ void OplDriver::close()
 // {
 // }
 
-void OplDriver::onStop() noexcept
+void OplDriver::onStop_() noexcept
 {
     for (auto it = m_voicesInUseIndex.begin(); it != m_voicesInUseIndex.end(); ++it)
     {
@@ -92,7 +92,7 @@ void OplDriver::onStop() noexcept
     }
 }
 
-void OplDriver::onPause() noexcept
+void OplDriver::onPause_() noexcept
 {
     for (auto it = m_voicesInUseIndex.begin(); it != m_voicesInUseIndex.end(); ++it)
     {
@@ -103,7 +103,7 @@ void OplDriver::onPause() noexcept
     }
 }
 
-void OplDriver::onResume() noexcept
+void OplDriver::onResume_() noexcept
 {
     for (auto it = m_voicesInUseIndex.begin(); it != m_voicesInUseIndex.end(); ++it)
     {

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
@@ -83,6 +83,15 @@ void OplDriver::close()
 // {
 // }
 
+void OplDriver::onStop() noexcept
+{
+    for (auto it = m_voicesInUseIndex.begin(); it != m_voicesInUseIndex.end(); ++it)
+    {
+        const uint8_t i = *it;
+        m_voices[i]->playNote(false);
+    }
+}
+
 void OplDriver::onPause() noexcept
 {
     for (auto it = m_voicesInUseIndex.begin(); it != m_voicesInUseIndex.end(); ++it)

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.hpp
@@ -40,9 +40,9 @@ public:
 
 protected:
     // void onCallback() noexcept override;
-    void onStop() noexcept override;
-    void onPause() noexcept override;
-    void onResume() noexcept override;
+    void onStop_() noexcept override;
+    void onPause_() noexcept override;
+    void onResume_() noexcept override;
 
     // MIDI Events
     void noteOff(const uint8_t chan, const uint8_t note) noexcept override;

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.hpp
@@ -40,6 +40,7 @@ public:
 
 protected:
     // void onCallback() noexcept override;
+    void onStop() noexcept override;
     void onPause() noexcept override;
     void onResume() noexcept override;
 

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplVoice.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplVoice.hpp
@@ -25,7 +25,7 @@ public:
     /// </summary>
     /// <param name="note"></param>
     /// <param name="sustain"></param>
-    /// <returns>true = voice released. false=voice sutained</returns>
+    /// <returns>true = voice released. false=voice sustained</returns>
     bool noteOff(const uint8_t note, const uint8_t sustain) noexcept;
     bool pitchBend(const uint16_t bend) noexcept;
     bool ctrl_modulationWheel(const uint8_t value) noexcept;

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
@@ -281,6 +281,11 @@ void MidiDriver_ADLIB::adlibWriteSecondary(uint8_t reg, uint8_t value)
 // }
 // }
 
+void MidiDriver_ADLIB::onStop() noexcept
+{
+    onPause();
+}
+
 void MidiDriver_ADLIB::onPause() noexcept
 {
     for (const auto& voice : m_voices)

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
@@ -281,12 +281,19 @@ void MidiDriver_ADLIB::adlibWriteSecondary(uint8_t reg, uint8_t value)
 // }
 // }
 
-void MidiDriver_ADLIB::onStop() noexcept
+void MidiDriver_ADLIB::onStop_() noexcept
 {
-    onPause();
+
+    for (auto& voice : m_voices)
+    {
+        if (voice.isFree())
+            continue;
+
+        mcOff(&voice);
+    }
 }
 
-void MidiDriver_ADLIB::onPause() noexcept
+void MidiDriver_ADLIB::onPause_() noexcept
 {
     for (const auto& voice : m_voices)
     {
@@ -297,7 +304,7 @@ void MidiDriver_ADLIB::onPause() noexcept
     }
 }
 
-void MidiDriver_ADLIB::onResume() noexcept
+void MidiDriver_ADLIB::onResume_() noexcept
 {
     for (const auto& voice : m_voices)
     {
@@ -618,7 +625,7 @@ void MidiDriver_ADLIB::mcOff(AdLibVoice* voice)
 
     if (voice->next)
         voice->next->prev = tmp;
-    if (tmp)
+    if (tmp != nullptr)
         tmp->next = voice->next;
     else
         toAdlibPart(voice->getChannel())->voice = voice->next;
@@ -679,9 +686,7 @@ void MidiDriver_ADLIB::adlibKeyOff(int chan)
     uint8_t reg = chan + 0xB0;
     adlibWrite(reg, adlibGetRegValue(reg) & ~0x20);
     if (m_opl3Mode)
-    {
         adlibWriteSecondary(reg, adlibGetRegValueSecondary(reg) & ~0x20);
-    }
 }
 
 uint8_t MidiDriver_ADLIB::struct10OnTimer(Struct10* s10, Struct11* s11)

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
@@ -283,7 +283,6 @@ void MidiDriver_ADLIB::adlibWriteSecondary(uint8_t reg, uint8_t value)
 
 void MidiDriver_ADLIB::onStop_() noexcept
 {
-
     for (auto& voice : m_voices)
     {
         if (voice.isFree())

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
@@ -41,6 +41,7 @@ public:
 
 protected:
     // void onCallback() noexcept override;
+    void onStop() noexcept override;
     void onPause() noexcept override;
     void onResume() noexcept override;
 

--- a/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
+++ b/hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
@@ -41,9 +41,9 @@ public:
 
 protected:
     // void onCallback() noexcept override;
-    void onStop() noexcept override;
-    void onPause() noexcept override;
-    void onResume() noexcept override;
+    void onStop_() noexcept override;
+    void onPause_() noexcept override;
+    void onResume_() noexcept override;
 
     // MIDI Events
     void noteOff(const uint8_t chan, const uint8_t note) noexcept override;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable MIDI stop handling: supported MIDI drivers now explicitly terminate active voices for cleaner, more responsive playback shutdown.
* **Bug Fixes**
  * Improved example playback control with a timed stop/restart sequence, plus more consistent device selection in the MIDI test harness.
* **Documentation**
  * Corrected a typo in OPL voice sustain documentation.
* **Chores**
  * Version bumped to 0.19.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->