### PR TITLE
chore(ci): update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: checkVersion
@@ -55,7 +55,7 @@ jobs:
     needs:
       - check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: publishVersion
         # if: ${{ github.ref == 'refs/heads/master' }}
         env:


### PR DESCRIPTION
## Why

Older major versions of these actions run on the deprecated Node 16 runtime, and the artifact actions at v3 and earlier were shut down by GitHub in early 2025, so affected workflows fail outright.

## Changes

- `.github/workflows/release.yml:29`: `actions/checkout@v3` -> `actions/checkout@v4`
- `.github/workflows/release.yml:58`: `actions/checkout@v3` -> `actions/checkout@v4`

---

Each change is a minimal, exact replacement. Found with a small maintenance tool and reviewed by a human. Happy to adjust the target versions or split this differently if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository checkout action used in workflow jobs to the latest major version, keeping automated checks and publishing steps current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->