### PR TITLE
Fix CMake Install

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -52,7 +52,7 @@ jobs:
         run: mkdir build
       - name: cmake generator
         run: |
-          cmake -D${{ matrix.use_mt32 }} -D${{ matrix.use_sdl }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+          cmake -DUSE_SPDLOG=ON -D${{ matrix.use_mt32 }} -D${{ matrix.use_sdl }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         working-directory: build
       - name: cmake build
         run: |

--- a/.github/workflows/ci-msys2.yml
+++ b/.github/workflows/ci-msys2.yml
@@ -28,7 +28,7 @@ jobs:
         use_mt32: [USE_MT32=ON]
         use_sdl: [USE_SDL3=OFF, USE_SDL3=ON, USE_SDL2=ON]
         os: ["2022"]
-    name: Build Windows
+    name: Build MSYS2
     runs-on: windows-${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci-msys2.yml
+++ b/.github/workflows/ci-msys2.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         use_mt32: [USE_MT32=ON]
-        use_sdl: [USE_SDL3=OFF,USE_SDL3=ON, USE_SDL2=ON]
+        use_sdl: [USE_SDL3=OFF, USE_SDL3=ON, USE_SDL2=ON]
         os: ["2022"]
     name: Build Windows
     runs-on: windows-${{ matrix.os }}
@@ -57,7 +57,7 @@ jobs:
         run: mkdir build
       - name: cmake generator
         run: |
-          cmake -G Ninja -D${{ matrix.use_mt32 }} -D${{ matrix.use_sdl }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/_install"  ..
+          cmake -G Ninja -D${{ matrix.use_mt32 }} -D${{ matrix.use_sdl }} -DUSE_SPDLOG=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/_install"  ..
         working-directory: build
       - name: cmake build
         run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -87,7 +87,7 @@ jobs:
         run: ctest -C ${{ matrix.build_type }} --output-on-failure
         working-directory: build
       - name: cmake install
-        run: cmake --build . --target install --config ${{ matrix.build_type }} -j4
+        run: cmake --build . --target install --config ${{ matrix.build_type }}
         working-directory: build
       - name: cmake package
         run: cmake --build . --target package --config ${{ matrix.build_type }} -j4

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -76,7 +76,7 @@ jobs:
       - name: cmake generator
         run: |
           . "${{ env.VS_PATH }}\VC\Auxiliary\Build\vcvars${{ env.ARCH }}.bat"
-          cmake -D${{ matrix.use_mt32 }} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -A ${{ env.CMAKE_A }} -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+          cmake -DUSE_SPDLOG=ON -D${{ matrix.use_mt32 }} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -A ${{ env.CMAKE_A }} -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         working-directory: build
       - name: cmake build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 
-project ("hyper-sonic-drivers" VERSION 0.19.6 DESCRIPTION "Hyper-Sonic Drivers for emulating old soundcards")
+project ("hyper-sonic-drivers" VERSION 0.19.7 DESCRIPTION "Hyper-Sonic Drivers for emulating old soundcards")
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)

--- a/hyper-sonic-drivers/CMakeLists.txt
+++ b/hyper-sonic-drivers/CMakeLists.txt
@@ -73,13 +73,6 @@ if(GENERATE_CODE_COVERAGE)
     )
 endif()
 
-install(
-    TARGETS ${LIB_NAME}
-    EXPORT ${LIB_CONF}
-    DESTINATION static/lib
-    PUBLIC_HEADER DESTINATION static/include
-)
-
 ## TODO: this is ok, but some includes files i don't want to be "public",
 ##       so it looks like it must be built manually..
 # try defining PUBLIC_HEADER than do an install target (it is at line 31)
@@ -104,10 +97,6 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion
   )
 
-install(EXPORT ${LIB_CONF}
-    DESTINATION static/cmake
-    NAMESPACE HyperSonicDrivers::
-)
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/${LIB_VER}.cmake
     DESTINATION static/cmake
@@ -246,39 +235,40 @@ target_link_libraries(${LIB_NAME}
 )
 
 if(USE_SPDLOG)
-    install(FILES
-        $<TARGET_FILE:${LIB_SPDLOG}
-        $<TARGET_LINKER_FILE:${LIB_SPDLOG}>
-        DESTINATION static/lib
-    )
-
     install(
-        TARGETS fmt
-        EXPORT ${LIB_CONF}
-        DESTINATION static/lib
-        PUBLIC_HEADER DESTINATION static/include
+        DIRECTORY ${fmt_SOURCE_DIR}/include/fmt/
+        DESTINATION include/fmt
     )
 
+    set_target_properties(fmt PROPERTIES PUBLIC_HEADER "")
     install(
-        TARGETS spdlog
+        TARGETS
+            fmt
+            spdlog
+            ${LIB_NAME}
         EXPORT ${LIB_CONF}
-        DESTINATION static/lib
+        RUNTIME DESTINATION static/bin
+        LIBRARY DESTINATION static/lib
+        ARCHIVE DESTINATION static/lib
         PUBLIC_HEADER DESTINATION static/include
-    )
-
-    export(TARGETS
-        ${LIB_NAME}
-        fmt
-        spdlog
-        FILE ${CMAKE_BINARY_DIR}/${LIB_NAME}.cmake
-        NAMESPACE HyperSonicDrivers::
     )
 else()
-    export(TARGETS ${LIB_NAME}
-        FILE ${CMAKE_BINARY_DIR}/${LIB_NAME}.cmake
-        NAMESPACE HyperSonicDrivers::
+
+    install(
+        TARGETS
+            ${LIB_NAME}
+        EXPORT ${LIB_CONF}
+        RUNTIME DESTINATION static/bin
+        LIBRARY DESTINATION static/lib
+        ARCHIVE DESTINATION static/lib
+        PUBLIC_HEADER DESTINATION static/include
     )
 endif()
+
+install(EXPORT ${LIB_CONF}
+    DESTINATION static/cmake
+    NAMESPACE HyperSonicDrivers::
+)
 
 if(USE_SDL3 OR USE_SDL2)
     install(FILES

--- a/hyper-sonic-drivers/CMakeLists.txt
+++ b/hyper-sonic-drivers/CMakeLists.txt
@@ -245,6 +245,7 @@ if(USE_SPDLOG)
         TARGETS
             fmt
             spdlog
+            rtaudio
             ${LIB_NAME}
         EXPORT ${LIB_CONF}
         RUNTIME DESTINATION static/bin
@@ -256,6 +257,7 @@ else()
 
     install(
         TARGETS
+            rtaudio
             ${LIB_NAME}
         EXPORT ${LIB_CONF}
         RUNTIME DESTINATION static/bin

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -9,6 +9,7 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(fmt)
+set(fmt_SOURCE_DIR ${fmt_SOURCE_DIR} PARENT_SCOPE)
 
 # spdlog
 set(SPDLOG_FMT_EXTERNAL ON)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated packaging so builds using spdlog include the required fmt and spdlog components.
  * Ensured installed library exports are consistently available to downstream projects.

* **Bug Fixes**
  * Enabled spdlog support explicitly in the MSYS2 CI build configuration.

* **Chores**
  * Bumped the project version from 0.19.6 to 0.19.7.
  * Improved build configuration handling for the fmt dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->